### PR TITLE
Disable autocomplete on member and guest inputs

### DIFF
--- a/resources/views/index.hbs
+++ b/resources/views/index.hbs
@@ -23,14 +23,14 @@
         <div class="sign-pages__page sign-pages__page--hidden" page-id="guest">
             <p class="sign-pages__page__message">Welcome, please enter your full name</p>
             <label class="input__label">Full Name
-                <input type="text" class="input" placeholder="" id="guestName" minlength="1" tabindex="1">
+                <input type="text" class="input" placeholder="" id="guestName" minlength="1" tabindex="1" autocomplete="off">>
             </label>
             <button id="guestSubmit" class="button" tabindex="2" disabled>Done</button>
         </div>
         <div class="sign-pages__page sign-pages__page--hidden" page-id="member">
             <p class="sign-pages__page__message">Welcome, please enter your name and select it from the list</p>
             <label class="input__label">Name
-                <input type="text" class="input" placeholder="" id="memberName" minlength="1" tabindex="3">
+                <input type="text" class="input" placeholder="" id="memberName" minlength="1" tabindex="3" autocomplete="off">
             </label>
             <button id="memberSubmit" class="button" disabled>Done</button>
             <div class="members__list" id="membersList" tabindex="4">


### PR DESCRIPTION
When using the app on mobile and some browsers, it tries to autocomplete the name with previously entered names, filling most of the screen with suggestions like "Ja".

AKA need browser to smortn't because otherwise it mean UXn't for the user